### PR TITLE
Use python3 rather than generic python interpreter

### DIFF
--- a/dcm2bids.py
+++ b/dcm2bids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Convert flat DICOM file set into a BIDS-compliant Nifti structure
 


### PR DESCRIPTION
Suggest we enforce python3.  If Python2 is the default on a system, I'm hitting some unicode assignment errors.