### PR TITLE
Updating dcm2bids.py to be compatible with sbref in dwi

### DIFF
--- a/dcm2bids.py
+++ b/dcm2bids.py
@@ -480,10 +480,10 @@ def bids_purpose_handling(bids_purpose, bids_intendedfor, seq_name,
 
         # Fill DWI bval and bvec working and source filenames
         # Non-empty filenames trigger the copy below
-        work_bval_fname = str(work_json_fname.replace('.json', '.bval'))
-        bids_bval_fname = str(bids_json_fname.replace('.json', '.bval'))
-        work_bvec_fname = str(work_json_fname.replace('.json', '.bvec'))
-        bids_bvec_fname = str(bids_json_fname.replace('.json', '.bvec'))
+        work_bval_fname = str(work_json_fname.replace('dwi.json', 'dwi.bval'))
+        bids_bval_fname = str(bids_json_fname.replace('dwi.json', 'dwi.bval'))
+        work_bvec_fname = str(work_json_fname.replace('dwi.json', 'dwi.bvec'))
+        bids_bvec_fname = str(bids_json_fname.replace('dwi.json', 'dwi.bvec'))
 
     # Populate BIDS source directory with Nifti images, JSON and DWI sidecars
     print('  Populating BIDS source directory')

--- a/docker_image/Dockerfile
+++ b/docker_image/Dockerfile
@@ -17,7 +17,7 @@ RUN cd /tmp && git clone https://github.com/rordenlab/dcm2niix.git && cd dcm2nii
 
 #Create a dir to store python script
 RUN mkdir WORKDIR /app
-COPY . /app
+COPY .. /app
 
 #Install required python depencendies (pydicom)
 RUN pip3 install pydicom


### PR DESCRIPTION
BIDS lets you save single band reference in the /dwi with _sbref tag. However current version of dcm2bids.py tried to handle .bval and .bvec from sbref which gave and error message. Not sure if this is the best solution...