### PR TITLE
To make it compatible with hub.docker.com autobuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# MAINTAINER: rnair@caltech.edu | feel free to copy and adapt as needed.| v1.1.2 of BIDSKIT
+FROM ubuntu:trusty
+
+# Install updates, Python3 for BIDS conversion script, Pip3 for Python to pull the pydicom module
+# git and make for building DICOM convertor from source + related dependencies
+# Clean up after to keep image size compact!
+RUN apt-get update && apt-get upgrade -y && apt-get install -y build-essential libjpeg-dev python3 python3-pip git cmake pkg-config pigz && \
+        apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y
+
+# Pull Chris Rorden's dcm2niix latest version from github and compile from source
+# Not including support for JPEG2000(optional -DUSE_OPENJPEG flag) and optional -DBATCH_VERSION flag (for batch processing binary dcm2niibatch
+# Include those flags with cmake, if required.
+RUN cd /tmp && git clone https://github.com/rordenlab/dcm2niix.git && cd dcm2niix && mkdir build && \
+        cd build && cmake .. && make && make install
+
+#dcm2niix executable has been created on /usr/local/bin within the container
+
+#Create a dir to store python script
+RUN mkdir WORKDIR /app
+COPY . /app
+
+#Install required python depencendies (pydicom)
+RUN pip3 install pydicom
+
+#Create an entrypoint to pass ARGS to python script
+ENTRYPOINT ["python3", "/app/dcm2bids.py"]
+
+#That's all. Enjoy! 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY . /app
 
 #Install required python depencendies (pydicom)
 RUN pip3 install pydicom
+RUN pip3 install numpy
 
 #Create an entrypoint to pass ARGS to python script
 ENTRYPOINT ["python3", "/app/dcm2bids.py"]

--- a/dcm2bids.py
+++ b/dcm2bids.py
@@ -221,7 +221,7 @@ def main():
                                  '-o', work_conv_dir, dcm_dir],
                                 stdout=devnull, stderr=subprocess.STDOUT)
 
-            else:
+            if not first_pass:
 
                 # Get subject age and sex from representative DICOM header
                 dcm_info = bids_dcm_info(dcm_dir)

--- a/docker_image/Dockerfile
+++ b/docker_image/Dockerfile
@@ -17,7 +17,7 @@ RUN cd /tmp && git clone https://github.com/rordenlab/dcm2niix.git && cd dcm2nii
 
 #Create a dir to store python script
 RUN mkdir WORKDIR /app
-COPY .. /app
+COPY . /app
 
 #Install required python depencendies (pydicom)
 RUN pip3 install pydicom


### PR DESCRIPTION
I moved Dockerfile one up and made changes so that repository would be compatible with hub.docker.com autobuild option (numpy had to be added to dockerfile).  Tested autobuild, it works this way. 

(Consider deleting docker_image folder to avoid duplication?)