### PR TITLE
Update dependencies

### DIFF
--- a/bidskit/__main__.py
+++ b/bidskit/__main__.py
@@ -79,7 +79,7 @@ def main():
     # nearest_fmap = args.nearest_fmap
 
     # Read version from setup.py
-    ver = pkg_resources.get_distribution('cbicqc').version
+    ver = pkg_resources.get_distribution('bidskit').version
 
     print('')
     print('------------------------------------------------------------')

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,7 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=['pydicom>=1.2.2',
+                      'pybids>=0.9.5',
                       'numpy>=1.15.2'],  # Optional
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
Update dependencies to include pybids when building from source, which I think is required to use the `BIDSLayout` class. Also change the package name that is used to determine the version number from `cbicqc` to `bidskit`, to resolve the following error:
```
Traceback (most recent call last):
  File "/usr/local/bin/bidskit", line 11, in <module>
    load_entry_point('bidskit==2019.8.16', 'console_scripts', 'bidskit')()
  File "/usr/local/lib/python3.7/site-packages/bidskit-2019.8.16-py3.7.egg/bidskit/__main__.py", line 82, in main
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 481, in get_distribution
    dist = get_provider(dist)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 357, in get_provider
    return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'cbicqc' distribution was not found and is required by the application
```

These changes should resolve https://github.com/jmtyszka/bidskit/issues/64.