### PR TITLE
Detect TaskName for seq_name other than 'EP'

### DIFF
--- a/bidskit/translate.py
+++ b/bidskit/translate.py
@@ -305,7 +305,7 @@ def purpose_handling(bids_purpose, bids_intendedfor, seq_name,
 
     if bids_purpose == 'func':
 
-        if seq_name == 'EP':
+        if 'EP' in seq_name:
 
             print('    EPI detected')
             create_events_template(bids_nii_fname, overwrite)


### PR DESCRIPTION
Just a minor suggestion to further improve upon the solution for issue #7: Right now, the `purpose_handling()` function in `translate.py` only reads the `TaskName` (from the file name) in case the scanning sequence name (`seq_name`) is exactly `'EP'`. In our fMRI files, for instance, the sequence name is `'EP\\GR'`, which leads to bidskit not adding the TaskName (and, further downstream, leads the BIDS validator to complain about TaskName missing).

In fact, I've wondered whether this second `if` statement is necessary at all. Wouldn't all functional scans (i.e., all `bids_purpose == 'func'`) need a TaskName according to the BIDS specification? I'm definitely not a BIDS export, though.

Thank you in advance for your efforts in considering this.