### PR TITLE
Pin pybids version to 0.12.4 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN cd /tmp && \
 RUN pip3 install cython scipy numpy pandas
 
 # Install python DICOM and BIDS packages
-RUN pip3 install pydicom pybids
+RUN pip3 install pydicom pybids==0.12.4
 
 # Install python3 bidskit in the container
 ADD . /myapp


### PR DESCRIPTION
Closes #81 by pinning the version of the pybids package to `0.12.4` in the Dockerfile. Otherwise, `docker run [...] bidskit` fails because it would use the most recent version of pybids (`0.13.1`).