### PR TITLE
update Dockerfile to ubuntu:22.04 and related dependencies

### DIFF
--- a/.bidsignore
+++ b/.bidsignore
@@ -1,1 +1,2 @@
 work/
+/dataset/*.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,20 @@
 # BIDSKIT 2020.08.01
 # MAINTAINER: jmt@caltech.edu
+# UPDATED: 2023.09.12 by lixiang@caltech.edu
 
-# Install Ubuntu 18.04 LTS Bionic Beaver
-FROM ubuntu:bionic
+# Install Ubuntu 22.04 LTS Bionic Beaver
+FROM ubuntu:22.04 
 
 # Install Node.js version 12
-FROM node:12
+FROM node:20
+
+VOLUME ["/dataset"]
+
+# redirect to archived-releases
+RUN echo "deb [trusted=yes] http://archive.debian.org/debian stretch main non-free contrib" > /etc/apt/sources.list && \
+    echo 'deb-src [trusted=yes] http://archive.debian.org/debian/ stretch main non-free contrib'  >> /etc/apt/sources.list && \
+    echo 'deb [trusted=yes] http://archive.debian.org/debian-security/ stretch/updates main non-free contrib'  >> /etc/apt/sources.list
+
 
 # Install updates, Python3 for BIDS conversion script, Pip3 for Python to pull the pydicom module
 # git and make for building DICOM convertor from source + related dependencies
@@ -18,7 +27,8 @@ RUN apt-get update && \
     apt-get autoremove -y
 
 # Install Node.js bids-validator
-RUN npm install -g bids-validator
+RUN npm install --global npm@^7 && \
+    npm install -g bids-validator
 
 # Pull Chris Rorden's dcm2niix latest version from github and compile from source
 # - dcm2niix is installed in /usr/local/bin within the container
@@ -31,6 +41,10 @@ RUN cd /tmp && \
     cd build && \
     cmake .. && \
     make install
+
+# avoid error: externally-managed-environment
+RUN PY_DIR=$(find /usr/lib -maxdepth 1 -type d | grep python3.*.) && \
+    mv $PY_DIR/EXTERNALLY-MANAGED $PY_DIR/EXTERNALLY-MANAGED.old
 
 # Install important python3 packages explicitly to avoid compilation errors from setup.py
 RUN pip3 install cython scipy numpy pandas

--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -49,21 +49,20 @@ docker build --platform linux/amd64 -t bidskit:latest .
 docker run -it -v --name bidskit /PATH_TO_YOUR_DATASET_FOLDER/:/dataset bidskit:latest -d /dataset
 ```
 
-If you're running *bidskit* from the shell you can either run *bidskit* without arguments from within the dataset root
-<pre>
-% cd /PATH_TO_YOUR_DATASET_FOLDER/
-% bidskit
-</pre>
+If you're running *bidskit* from the shell you can either run *bidskit* without arguments from within the `/dataset` root
+```bash
+cd /PATH_TO_YOUR_DATASET_FOLDER/
+bidskit
+```
 
 or from another folder by specifying the BIDS dataset directory
 
-<pre>
-% bidskit -d /PATH_TO_YOUR_DATASET_FOLDER/ 
-</pre>
-
+```bash
+bidskit -d /PATH_TO_YOUR_DATASET_FOLDER/
+```
 
 The first pass conversion constructs a BIDS-compliant directory tree around sourcedata/ with required text files,
-including a translator dictionary (Protocol_Translator.json) in the code/ subdirectory:
+including a translator dictionary (Protocol_Translator.json) in the `code/` subdirectory:
 
 #### BIDS Dataset after First Pass Conversion
 <pre>
@@ -95,9 +94,9 @@ learning_pilot_2019/
 
 #### Conversion without Sessions
 You can omit the use of session subdirectories if you only have one session per subject. Use the --no-sessions command line flag to achieve this (this feature is switched off by default):
-<pre>
-% bidskit -d /PATH_TO_YOUR_DATASET_FOLDER/ --no-sessions
-</pre>
+```bash
+bidskit -d /PATH_TO_YOUR_DATASET_FOLDER/ --no-sessions
+```
 
 ### Editing the Translator Dictionary
 

--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -39,9 +39,15 @@ which controls the conversion of your original MRI series into a BIDS-compliant 
 ### First Pass Conversion
 
 If you're using the Docker image, run the following:
-<pre>
+```bash
 docker run -it -v /PATH_TO_YOUR_DATASET_FOLDER/:/dataset jmtyszka/bidskit bidskit -d /dataset
-</pre>
+```
+For Mac M1 user, build your image with argument `--platform linux/amd64`
+```bash
+# cd to root dir which contains Dockerfile
+docker build --platform linux/amd64 -t bidskit:latest .
+docker run -it -v --name bidskit /PATH_TO_YOUR_DATASET_FOLDER/:/dataset bidskit:latest -d /dataset
+```
 
 If you're running *bidskit* from the shell you can either run *bidskit* without arguments from within the dataset root
 <pre>


### PR DESCRIPTION
The previous Dockerfile is out-of-date, mostly because ubuntu:18.04 is not maintaining. So here I updated it to 22.04 LTS, as well as python3.11, node20 and npm7. Some version-dependent issues were fixed, including: unable to find repository releases, externally-managed error, etc.
I also updated a few documentations, especially for docker usage.